### PR TITLE
[OPS-1127] Protect from flood of obsolete SSL clients

### DIFF
--- a/servers/sadalbari/default.nix
+++ b/servers/sadalbari/default.nix
@@ -4,6 +4,7 @@
     inputs.serokell-nix.nixosModules.hetzner-cloud
     inputs.hackage-search.module
     ./hackage-search.nix
+    ./fail2ban.nix
   ];
 
   networking.hostName = "sadalbari";

--- a/servers/sadalbari/fail2ban.nix
+++ b/servers/sadalbari/fail2ban.nix
@@ -1,0 +1,32 @@
+{
+  # Disable access log to avoid flooding
+  services.nginx.commonHttpConfig = ''
+    access_log off;
+  '';
+
+  services.fail2ban = {
+    enable = true;
+
+    # Ban clients abusing old SSL
+    jails.nginx-old-ssl = ''
+      enabled = true
+      filter = nginx-old-ssl
+      maxretry = 2
+      bantime = 432000 ; 5 days
+      findtime = 600 ; 10 minutes
+    '';
+  };
+
+  environment.etc."fail2ban/filter.d/nginx-old-ssl.conf" = {
+    enable = true;
+    text = ''
+      [Definition]
+      failregex = ^.* error:1408F0C6:SSL .* client: <HOST>, .*$
+      port = http,https
+      backend = systemd
+      journalmatch = SYSLOG_IDENTIFIER=nginx
+      banaction = iptables-allports[name="nginx-old-ssl"]
+    '';
+  };
+
+}


### PR DESCRIPTION
Error code 1408F0C6 signifies an SSL handshake error caused by obsolete clients. There was a huge number of these swamping the logs.

Add custom fail2ban filter matching on error 1408F0C6, and a pretty aggressive jail for it.

Disable nginx access logs entirely to prevent disk flooding.

We should consider adding this to all our servers, but let's see how it goes for a few days first.