### PR TITLE
Make sure our oauth2_proxy fork is used only for serokell-website

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -4,8 +4,6 @@ let
 in {
   imports = [
     inputs.serokell-nix.nixosModules.common
-    inputs.serokell-nix.nixosModules.oauth2_proxy
-    inputs.serokell-nix.nixosModules.oauth2_proxy_nginx
     inputs.serokell-nix.nixosModules.serokell-users
     inputs.serokell-nix.nixosModules.vault-secrets
   ];

--- a/lib/modules/oauth2_proxy.nix
+++ b/lib/modules/oauth2_proxy.nix
@@ -1,0 +1,575 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# NixOS module for oauth2_proxy.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.oauth2_proxy;
+
+  # oauth2_proxy provides many options that are only relevant if you are using
+  # a certain provider. This set maps from provider name to a function that
+  # takes the configuration and returns a string that can be inserted into the
+  # command-line to launch oauth2_proxy.
+  providerSpecificOptions = {
+    azure = cfg: {
+      azure.tenant = cfg.azure.tenant;
+      resource = cfg.azure.resource;
+    };
+
+    github = cfg: { github = {
+      inherit (cfg.github) org team;
+    }; };
+
+    google = cfg: { google = with cfg.google; optionalAttrs (groups != []) {
+      admin-email = adminEmail;
+      service-account = serviceAccountJSON;
+      group = groups;
+    }; };
+  };
+
+  authenticatedEmailsFile = pkgs.writeText "authenticated-emails" cfg.email.addresses;
+
+  getProviderOptions = cfg: provider: providerSpecificOptions.${provider} or (_: {}) cfg;
+
+  allConfig = with cfg; {
+    inherit (cfg) provider scope upstream;
+    approval-prompt = approvalPrompt;
+    basic-auth-password = basicAuthPassword;
+    client-id = clientID;
+    client-secret = clientSecret;
+    custom-templates-dir = customTemplatesDir;
+    email-domain = email.domains;
+    http-address = httpAddress;
+    login-url = loginURL;
+    pass-access-token = passAccessToken;
+    pass-basic-auth = passBasicAuth;
+    pass-host-header = passHostHeader;
+    proxy-prefix = proxyPrefix;
+    profile-url = profileURL;
+    redeem-url = redeemURL;
+    redirect-url = redirectURL;
+    request-logging = requestLogging;
+    skip-auth-regex = skipAuthRegexes;
+    signature-key = signatureKey;
+    validate-url = validateURL;
+    htpasswd-file = htpasswd.file;
+    cookie = {
+      inherit (cookie) domain secure expire name secret refresh;
+      httponly = cookie.httpOnly;
+    };
+    set-xauthrequest = setXauthrequest;
+  } // lib.optionalAttrs (cfg.email.addresses != null) {
+    authenticated-emails-file = authenticatedEmailsFile;
+  } // lib.optionalAttrs (cfg.passBasicAuth) {
+    basic-auth-password = cfg.basicAuthPassword;
+  } // lib.optionalAttrs (cfg.htpasswd.file != null) {
+    display-htpasswd-file = cfg.htpasswd.displayForm;
+  } // lib.optionalAttrs tls.enable {
+    tls-cert = tls.certificate;
+    tls-key = tls.key;
+    https-address = tls.httpsAddress;
+  } // (getProviderOptions cfg cfg.provider) // cfg.extraConfig;
+
+  mapConfig = key: attr:
+  if attr != null && attr != [] then (
+    if isDerivation attr then mapConfig key (toString attr) else
+    if (builtins.typeOf attr) == "set" then concatStringsSep " "
+      (mapAttrsToList (name: value: mapConfig (key + "-" + name) value) attr) else
+    if (builtins.typeOf attr) == "list" then concatMapStringsSep " " (mapConfig key) attr else
+    if (builtins.typeOf attr) == "bool" then "--${key}=${boolToString attr}" else
+    if (builtins.typeOf attr) == "string" then "--${key}='${attr}'" else
+    "--${key}=${toString attr}")
+    else "";
+
+  configString = concatStringsSep " " (mapAttrsToList mapConfig allConfig);
+in
+{
+  disabledModules = [ "services/security/oauth2_proxy.nix" ];
+  options.services.oauth2_proxy = {
+    enable = mkEnableOption "oauth2_proxy";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.oauth2_proxy;
+      defaultText = "pkgs.oauth2_proxy";
+      description = ''
+        The package that provides oauth2_proxy.
+      '';
+    };
+
+    ##############################################
+    # PROVIDER configuration
+    # Taken from: https://github.com/oauth2-proxy/oauth2-proxy/blob/master/providers/providers.go
+    provider = mkOption {
+      type = types.enum [
+        "google"
+        "github"
+        "azure"
+        "gitlab"
+        "linkedin"
+        "myusa"
+      ];
+      default = "google";
+      description = ''
+        OAuth provider.
+      '';
+    };
+
+    approvalPrompt = mkOption {
+      type = types.enum ["force" "auto"];
+      default = "force";
+      description = ''
+        OAuth approval_prompt.
+      '';
+    };
+
+    clientID = mkOption {
+      type = types.nullOr types.str;
+      description = ''
+        The OAuth Client ID.
+      '';
+      example = "123456.apps.googleusercontent.com";
+    };
+
+    clientSecret = mkOption {
+      type = types.nullOr types.str;
+      description = ''
+        The OAuth Client Secret.
+      '';
+    };
+
+    skipAuthRegexes = mkOption {
+     type = types.listOf types.str;
+     default = [];
+     description = ''
+       Skip authentication for requests matching any of these regular
+       expressions.
+     '';
+    };
+
+    # XXX: Not clear whether these two options are mutually exclusive or not.
+    email = {
+      domains = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Authenticate emails with the specified domains. Use
+          <literal>*</literal> to authenticate any email.
+        '';
+      };
+
+      addresses = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = ''
+          Line-separated email addresses that are allowed to authenticate.
+        '';
+      };
+    };
+
+    loginURL = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Authentication endpoint.
+
+        You only need to set this if you are using a self-hosted provider (e.g.
+        Github Enterprise). If you're using a publicly hosted provider
+        (e.g github.com), then the default works.
+      '';
+      example = "https://provider.example.com/oauth/authorize";
+    };
+
+    redeemURL = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Token redemption endpoint.
+
+        You only need to set this if you are using a self-hosted provider (e.g.
+        Github Enterprise). If you're using a publicly hosted provider
+        (e.g github.com), then the default works.
+      '';
+      example = "https://provider.example.com/oauth/token";
+    };
+
+    validateURL = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Access token validation endpoint.
+
+        You only need to set this if you are using a self-hosted provider (e.g.
+        Github Enterprise). If you're using a publicly hosted provider
+        (e.g github.com), then the default works.
+      '';
+      example = "https://provider.example.com/user/emails";
+    };
+
+    redirectURL = mkOption {
+      # XXX: jml suspects this is always necessary, but the command-line
+      # doesn't require it so making it optional.
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The OAuth2 redirect URL.
+      '';
+      example = "https://internalapp.yourcompany.com/oauth2/callback";
+    };
+
+    azure = {
+      tenant = mkOption {
+        type = types.str;
+        default = "common";
+        description = ''
+          Go to a tenant-specific or common (tenant-independent) endpoint.
+        '';
+      };
+
+      resource = mkOption {
+        type = types.str;
+        description = ''
+          The resource that is protected.
+        '';
+      };
+    };
+
+    google = {
+      adminEmail = mkOption {
+        type = types.str;
+        description = ''
+          The Google Admin to impersonate for API calls.
+
+          Only users with access to the Admin APIs can access the Admin SDK
+          Directory API, thus the service account needs to impersonate one of
+          those users to access the Admin SDK Directory API.
+
+          See <link xlink:href="https://developers.google.com/admin-sdk/directory/v1/guides/delegation#delegate_domain-wide_authority_to_your_service_account" />.
+        '';
+      };
+
+      groups = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Restrict logins to members of these Google groups.
+        '';
+      };
+
+      serviceAccountJSON = mkOption {
+        type = types.path;
+        description = ''
+          The path to the service account JSON credentials.
+        '';
+      };
+    };
+
+    github = {
+      org = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Restrict logins to members of this organisation.
+        '';
+      };
+
+      team = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Restrict logins to members of this team.
+        '';
+      };
+    };
+
+
+    ####################################################
+    # UPSTREAM Configuration
+    upstream = mkOption {
+      type = with types; coercedTo str (x: [x]) (listOf str);
+      default = [];
+      description = ''
+        The http url(s) of the upstream endpoint or <literal>file://</literal>
+        paths for static files. Routing is based on the path.
+      '';
+    };
+
+    passAccessToken = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Pass OAuth access_token to upstream via X-Forwarded-Access-Token header.
+      '';
+    };
+
+    passBasicAuth = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream.
+      '';
+    };
+
+    basicAuthPassword = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The password to set when passing the HTTP Basic Auth header.
+      '';
+    };
+
+    passHostHeader = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Pass the request Host Header to upstream.
+      '';
+    };
+
+    signatureKey = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        GAP-Signature request signature key.
+      '';
+      example = "sha1:secret0";
+    };
+
+    cookie = {
+      domain = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Optional cookie domains to force cookies to (ie: `.yourcompany.com`).
+          The longest domain matching the request's host will be used (or the shortest
+          cookie domain if there is no match).
+        '';
+        example = ".yourcompany.com";
+      };
+
+      expire = mkOption {
+        type = types.str;
+        default = "168h0m0s";
+        description = ''
+          Expire timeframe for cookie.
+        '';
+      };
+
+      httpOnly = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Set HttpOnly cookie flag.
+        '';
+      };
+
+      name = mkOption {
+        type = types.str;
+        default = "_oauth2_proxy";
+        description = ''
+          The name of the cookie that the oauth_proxy creates.
+        '';
+      };
+
+      refresh = mkOption {
+        # XXX: Unclear what the behavior is when this is not specified.
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Refresh the cookie after this duration; 0 to disable.
+        '';
+        example = "168h0m0s";
+      };
+
+      secret = mkOption {
+        type = types.nullOr types.str;
+        description = ''
+          The seed string for secure cookies.
+        '';
+      };
+
+      secure = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Set secure (HTTPS) cookie flag.
+        '';
+      };
+    };
+
+    ####################################################
+    # OAUTH2 PROXY configuration
+
+    httpAddress = mkOption {
+      type = types.str;
+      default = "http://127.0.0.1:4180";
+      description = ''
+        HTTPS listening address.  This module does not expose the port by
+        default. If you want this URL to be accessible to other machines, please
+        add the port to <literal>networking.firewall.allowedTCPPorts</literal>.
+      '';
+    };
+
+    htpasswd = {
+      file = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Additionally authenticate against a htpasswd file. Entries must be
+          created with <literal>htpasswd -s</literal> for SHA encryption.
+        '';
+      };
+
+      displayForm = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Display username / password login form if an htpasswd file is provided.
+        '';
+      };
+    };
+
+    customTemplatesDir = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to custom HTML templates.
+      '';
+    };
+
+    proxyPrefix = mkOption {
+      type = types.str;
+      default = "/oauth2";
+      description = ''
+        The url root path that this proxy should be nested under.
+      '';
+    };
+
+    tls = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to serve over TLS.
+        '';
+      };
+
+      certificate = mkOption {
+        type = types.path;
+        description = ''
+          Path to certificate file.
+        '';
+      };
+
+      key = mkOption {
+        type = types.path;
+        description = ''
+          Path to private key file.
+        '';
+      };
+
+      httpsAddress = mkOption {
+        type = types.str;
+        default = ":443";
+        description = ''
+          <literal>addr:port</literal> to listen on for HTTPS clients.
+
+          Remember to add <literal>port</literal> to
+          <literal>allowedTCPPorts</literal> if you want other machines to be
+          able to connect to it.
+        '';
+      };
+    };
+
+    requestLogging = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Log requests to stdout.
+      '';
+    };
+
+    ####################################################
+    # UNKNOWN
+
+    # XXX: Is this mandatory? Is it part of another group? Is it part of the provider specification?
+    scope = mkOption {
+      # XXX: jml suspects this is always necessary, but the command-line
+      # doesn't require it so making it optional.
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        OAuth scope specification.
+      '';
+    };
+
+    profileURL = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+      	Profile access endpoint.
+      '';
+    };
+
+    setXauthrequest = mkOption {
+      type = types.nullOr types.bool;
+      default = false;
+      description = ''
+        Set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode). Setting this to 'null' means using the upstream default (false).
+      '';
+    };
+
+    extraConfig = mkOption {
+      default = {};
+      description = ''
+        Extra config to pass to oauth2-proxy.
+      '';
+    };
+
+    keyFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        oauth2-proxy allows passing sensitive configuration via environment variables.
+        Make a file that contains lines like
+        OAUTH2_PROXY_CLIENT_SECRET=asdfasdfasdf.apps.googleuserscontent.com
+        and specify the path here.
+      '';
+      example = "/run/keys/oauth2_proxy";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    services.oauth2_proxy = mkIf (cfg.keyFile != null) {
+      clientID = mkDefault null;
+      clientSecret = mkDefault null;
+      cookie.secret = mkDefault null;
+    };
+
+    users.users.oauth2_proxy = {
+      description = "OAuth2 Proxy";
+      isSystemUser = true;
+    };
+
+    systemd.services.oauth2_proxy = {
+      description = "OAuth2 Proxy";
+      path = [ cfg.package ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        User = "oauth2_proxy";
+        Restart = "always";
+        ExecStart = "${cfg.package}/bin/oauth2_proxy ${configString}";
+        EnvironmentFile = mkIf (cfg.keyFile != null) cfg.keyFile;
+      };
+    };
+
+  };
+}

--- a/lib/modules/oauth2_proxy_nginx.nix
+++ b/lib/modules/oauth2_proxy_nginx.nix
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{ config, lib, ... }:
+with lib;
+let
+  cfg = config.services.oauth2_proxy.nginx;
+  vhostmod.options = {
+    applicationChecksAuth = mkEnableOption "The backend will check the auth headers, always forward";
+    host = mkOption {
+      type = types.str;
+      example = "serokell.io";
+      default = "$host";
+    };
+  };
+in
+{
+  disabledModules = [ "services/security/oauth2_proxy_nginx.nix" ];
+  options.services.oauth2_proxy.nginx = {
+    proxy = mkOption {
+      type = types.str;
+      default = config.services.oauth2_proxy.httpAddress;
+      description = ''
+        The address of the reverse proxy endpoint for oauth2_proxy
+      '';
+    };
+    virtualHosts = mkOption {
+      type = with types; coercedTo (listOf str) (l: lib.genAttrs l (_:{})) (attrsOf (submodule vhostmod));
+      default = {};
+      description = ''
+        A list of nginx virtual hosts to put behind the oauth2 proxy
+      '';
+    };
+  };
+  config.services.oauth2_proxy = mkIf (cfg.virtualHosts != [] && (hasPrefix "127.0.0.1:" cfg.proxy)) {
+    enable = true;
+  };
+  config.services.nginx = mkMerge ((optional (cfg.virtualHosts != {}) {
+    recommendedProxySettings = true; # needed because duplicate headers
+  }) ++ (lib.mapAttrsToList (vhost: opts: {
+    virtualHosts.${vhost} = {
+      locations."/oauth2/" = {
+        proxyPass = cfg.proxy;
+        extraConfig = ''
+          proxy_set_header X-Scheme                $scheme;
+          proxy_set_header X-Auth-Request-Redirect $scheme://${opts.host}$request_uri;
+          proxy_set_header Host ${opts.host};
+        '';
+      };
+      locations."/oauth2/auth" = {
+        # oauth2_proxy patched to accept headersOnly query param that always returns 202, but sets the headers
+        # when logged in
+        proxyPass = cfg.proxy + (lib.optionalString opts.applicationChecksAuth "/oauth2/auth?headersOnly=true");
+        extraConfig = ''
+          proxy_set_header X-Scheme         $scheme;
+          # nginx auth_request includes headers but not body
+          proxy_set_header Content-Length   "";
+          proxy_pass_request_body           off;
+        '';
+      };
+      locations."/".extraConfig = ''
+        auth_request /oauth2/auth;
+        error_page 401 = /oauth2/sign_in;
+
+        # pass information via X-User and X-Email headers to backend,
+        # requires running with --set-xauthrequest flag
+        auth_request_set $user   $upstream_http_x_auth_request_user;
+        auth_request_set $email  $upstream_http_x_auth_request_email;
+        proxy_set_header X-User  $user;
+        proxy_set_header X-Email $email;
+
+        # if you enabled --cookie-refresh, this is needed for it to work with auth_request
+        auth_request_set $auth_cookie $upstream_http_set_cookie;
+        add_header Set-Cookie $auth_cookie;
+        ${lib.optionalString opts.applicationChecksAuth "proxy_intercept_errors on;"}
+      '';
+
+    };
+  }) cfg.virtualHosts));
+}

--- a/lib/modules/website.nix
+++ b/lib/modules/website.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ...}:
+{ config, lib, pkgs, inputs, ...}:
 with lib;
 let
   vs = config.vault-secrets.secrets;
@@ -6,6 +6,11 @@ let
   port = 8080;
   profile = "/nix/var/nix/profiles/per-user/${name}/www";
 in {
+  imports = [
+    inputs.serokell-nix.nixosModules.oauth2_proxy
+    inputs.serokell-nix.nixosModules.oauth2_proxy_nginx
+  ];
+
   users.users.${name} = {
     createHome = true;
     home = "/var/lib/${name}";

--- a/lib/modules/website.nix
+++ b/lib/modules/website.nix
@@ -1,14 +1,18 @@
-{ config, lib, pkgs, inputs, ...}:
+{ config, lib, pkgs, ...}:
 with lib;
 let
   vs = config.vault-secrets.secrets;
   name = "www";
   port = 8080;
   profile = "/nix/var/nix/profiles/per-user/${name}/www";
+
+  # custom oauth2_proxy package which allows the website to check auth itself
+  oauth2_proxy-serokell = pkgs.callPackage ../packages/oauth2_proxy {};
+
 in {
   imports = [
-    inputs.serokell-nix.nixosModules.oauth2_proxy
-    inputs.serokell-nix.nixosModules.oauth2_proxy_nginx
+    ./oauth2_proxy.nix
+    ./oauth2_proxy_nginx.nix
   ];
 
   users.users.${name} = {
@@ -36,6 +40,8 @@ in {
     inherit (config.networking) domain hostName;
   in {
     enable = true;
+    package = oauth2_proxy-serokell;
+
     email.domains = [ "serokell.io" ];
     keyFile = "${vs.oauth2_proxy}/environment";
     setXauthrequest = true;

--- a/lib/packages/oauth2_proxy/default.nix
+++ b/lib/packages/oauth2_proxy/default.nix
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "oauth2_proxy-${version}";
+  version = "20200506-${lib.strings.substring 0 7 rev}";
+  rev = "d1a697508ee73081a82e558424e15f07953bc589";
+
+  goPackagePath = "github.com/pusher/oauth2_proxy";
+
+  src = fetchFromGitHub {
+    repo = "oauth2_proxy";
+    owner = "serokell";
+    inherit rev;
+    sha256 = "02vrrv9iyj0ky229chsjwl9x1xbvw53k991hpn46zxgc90k5qj4s";
+  };
+
+  goDeps = ./deps.nix;
+
+  # we use a custom patch which breaks the tests
+  doCheck = false;
+}

--- a/lib/packages/oauth2_proxy/deps.nix
+++ b/lib/packages/oauth2_proxy/deps.nix
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev =  "2d3a6656c17a60b0815b7e06ab0be04eacb6e613";
+      sha256 = "0fi3qj9fvc4bxbrwa1m5sxsb8yhvawiwigaddvmmizjykxbq5csq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev =  "b26d9c308763d68093482582cea63d69be07a0f0";
+      sha256 = "0k7v2i1d2d6si8gswn83qb84czhhia53v2wdy33yz9ppdidxk0ry";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bitly/go-simplejson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bitly/go-simplejson";
+      rev =  "aabad6e819789e569bd6aabf444c935aa9ba1e44";
+      sha256 = "0n9f9dz1jn1jx86d48569nznpjn9fmq3knn7r65xpy7jhih284jj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/coreos/go-oidc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-oidc";
+      rev =  "77e7f2010a464ade7338597afe650dfcffbe2ca8";
+      sha256 = "0mh8fa7al9gfzx4k7rd623bpy14s06s96iz6lbf6psi5q2bnbs2r";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev =  "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e";
+      sha256 = "08m27vlms74pfy5z79w67f9lk9zkx6a9jd68k3c4msxy75ry36mp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "1e59b77b52bf8e4b449a57e6f79f21226d571845";
+      sha256 = "19bkh81wnp6njg3931wky6hsnnl2d1ig20vfjxpv450sd3k6yys8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mbland/hmacauth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mbland/hmacauth";
+      rev =  "107c17adcc5eccc9935cd67d9bc2feaf5255d2cb";
+      sha256 = "1zd9r8znhkxyl997lhjk8nrlxlfv5s1hn7ql87wrcyvlsszx3mzh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mreiferson/go-options";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mreiferson/go-options";
+      rev =  "20ba7d382d05facb01e02eb777af0c5f229c5c95";
+      sha256 = "1vdz3wqkj885a0jkggaygl4k6k8b94fpspywr26snm4xnb8vgxsf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pquerna/cachecontrol";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pquerna/cachecontrol";
+      rev =  "0dec1b30a0215bb68605dfc568e8855066c9202d";
+      sha256 = "14yyfhrv60rvb983rqm7s916nwvn9kcmbvnrcna2md0s3mkzs3yh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "69483b4bd14f5845b5a1e55bca19e954e827f1d0";
+      sha256 = "11lzrwkdzdd8yyag92akncc008h2f9d1bpc489mxiwp0jrmz4ivb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/yhat/wsutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/yhat/wsutil";
+      rev =  "1d66fa95c997864ba4d8479f56609620fe542928";
+      sha256 = "1agh4ss6y1laps8pg4mdl844ivmw2wrb7rnpfyag4gai4693i7bv";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94";
+      sha256 = "1mhmr6ljzl3iafsz4qy8vval7rmr828wh59dlqqqjqx6sqmcs1dv";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "9dfe39835686865bff950a07b394c12a98ddc811";
+      sha256 = "0z8mnl4mi88syafrgqys2ak2gg3yrbna25hpz88y3anl8x4jhg1a";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402";
+      sha256 = "035v5w1nad6r1l22cj6f73zzr6qi4jgq71yjywf2c6rvsa5147r2";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-api-go-client";
+      rev =  "8791354e7ab150705ede13637a18c1fcc16b62e8";
+      sha256 = "0ps7y4m9787wvkqwrwqyb4nmmibhrihmg7xqh7sba2cyj397wngm";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "150dc57a1b433e64154302bdc40b6bb8aefa313a";
+      sha256 = "0w3knznv39k8bm85ri62f83czcrxknql7dv6p9hk1a5jx3xljgxq";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/fsnotify/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev =  "836bfd95fecc0f1511dd66bdbf2b5b61ab8b00b6";
+      sha256 = "0470dznkcbabncskgr8hfilpj5w24ygg455pyggbfbssmfv1m9gg";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/square/go-jose.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/square/go-jose";
+      rev =  "f8f38de21b4dcd69d0413faf231983f5fd6634b1";
+      sha256 = "1bjrs3xq3m2ckfds0l4wqf81311ymm9agipmkllbvkadac156dsa";
+    };
+  }
+]


### PR DESCRIPTION
Our fork has known vulnerabilities (https://github.com/oauth2-proxy/oauth2-proxy/security/advisories/GHSA-5m6c-jp6f-2vcv), but we don't know if
serokell-website needs the features our fork implements or not, so we
cannot just switch it to the upstream module. But we know that we don't
the fork for any other service, so we should limit it to
serokell-website

Related issue: https://issues.serokell.io/issue/INT-158