### PR TITLE
[OPS-1106] Move ariadne-landing from jupiter to enif

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Serokell's web app servers
 
 ## Servers
 
-| Name      | Provider      | Function               |
-|-----------|---------------|------------------------|
-| helvetios | EC2           | serokell.io staging    |
-| enif      | EC2           | serokell.io production |
-| matar     | EC2           | postgresql             |
-| sadalbari | Hetzner Cloud | hackage-search         |
-| markab    | Hetzner Cloud | YouTrack               |
+| Name      | Provider      | Function                                |
+|-----------|---------------|-----------------------------------------|
+| helvetios | EC2           | serokell.io staging                     |
+| enif      | EC2           | serokell.io production, ariadne-landing |
+| matar     | EC2           | postgresql                              |
+| sadalbari | Hetzner Cloud | hackage-search                          |
+| markab    | Hetzner Cloud | YouTrack                                |
 
 
 ## Network

--- a/servers/enif/ariadne-landing.nix
+++ b/servers/enif/ariadne-landing.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+let
+  profile = "/nix/var/nix/profiles/per-user/www/ariadne-landing";
+  port = 8120;
+
+in {
+  # used by buildkite for deploying updates from ariadne-landing CI
+  users.users.bk-ariadne-landing = {
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMwZWnQ5Oqkjkfjw/dZsjP3jIL6f3xT73DOb5+L5mxpo" ];
+  };
+
+  systemd.services.ariadne-landing = {
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      ExecStart = "${profile}/bin/npm start --port=${toString port}";
+      DynamicUser = true;
+    };
+  };
+
+  # allow buildkite to restart the service for CD
+  security.sudo.extraRules = [{
+    users = [ "bk-ariadne-landing" ];
+    commands = [{
+      command = "/run/current-system/sw/bin/systemctl restart ariadne-landing";
+      options = [ "NOPASSWD" ];
+    }];
+  }];
+
+  services.nginx.virtualHosts.www = {
+    # proxy serokell.io/ariadne to the ariadne-landing service
+    locations."/ariadne".proxyPass = "http://127.0.0.1:${toString port}";
+  };
+}

--- a/servers/enif/ariadne-landing.nix
+++ b/servers/enif/ariadne-landing.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  profile = "/nix/var/nix/profiles/per-user/www/ariadne-landing";
+  profile = "/nix/var/nix/profiles/per-user/bk-ariadne-landing/ariadne-landing";
   port = 8120;
 
 in {

--- a/servers/enif/default.nix
+++ b/servers/enif/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     "${modulesPath}/virtualisation/amazon-image.nix"
+    ./ariadne-landing.nix
     ./backups.nix
     ./website.nix
   ];


### PR DESCRIPTION
The landing was served at `serokell.io/ariadne`, so the simplest way to make it work is to run it on enif, because enif serves `serokell.io` domain. The service config is copied from jupiter. Jupiter also had a staging instance for the landing, but it's not needed because the website is not in active development.

We could also put it in a static S3 bucket and configure cloudfront to serve `serokell.io/ariadne` from the bucket (or use a separate domain for ariadne), I can do that instead if anyone prefers it.