### PR TITLE
[OPS-1081] serokell-website: don't intercept 404 error from backend, clean up nginx config

### DIFF
--- a/lib/modules/website.nix
+++ b/lib/modules/website.nix
@@ -81,7 +81,6 @@ in {
           proxyPass = "http://127.0.0.1:${toString port}";
           extraConfig = ''
             proxy_set_header X-User  $user;
-            error_page 404 = /404;
           '';
         };
 

--- a/lib/modules/website.nix
+++ b/lib/modules/website.nix
@@ -79,17 +79,12 @@ in {
 
         "/" = {
           proxyPass = "http://127.0.0.1:${toString port}";
-          extraConfig = ''
-            proxy_set_header X-User  $user;
-          '';
         };
 
         "/api" = {
           proxyPass = "http://127.0.0.1:${toString port}";
           extraConfig = ''
-            proxy_intercept_errors off;
             expires -1;
-            error_page 404 = /404;
 
             auth_request /oauth2/auth;
             error_page 401 = /oauth2/sign_in;


### PR DESCRIPTION
We have `proxy_intercept_errors` nginx option enabled for serokell-website prod, so that when backend returns 401 status code for a path, nginx will intercept it and redirect request to the login page for oauth2_proxy (specified by `error_page 401 = /oauth2/sign_in` setting). But the website wants a custom 404 page, so we don't want to intercept 404 errors. Removing `error_page 404` should fix it.

I've also removed some redundant options from the config, see commit messages for explanation.