### PR TITLE
[OPS-1146] Set ipv6 address for hetzner cloud instances statically

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1610610970,
-        "narHash": "sha256-QFqpQYehijJ0Jum2scWVHGoBa8utyY73m5p8oRGioc0=",
+        "lastModified": 1611039094,
+        "narHash": "sha256-UsdM3/HskZIQHgSO+RjotP0sc+8ZjLMJYJ8hfmUjTAA=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "07fa57f08e2428e2c2780b559090c250d51236fe",
+        "rev": "c9aa8bcaf18287c2bb93fc63870baaf6298c8217",
         "type": "github"
       },
       "original": {

--- a/servers/markab/default.nix
+++ b/servers/markab/default.nix
@@ -7,4 +7,6 @@
   ];
 
   networking.hostName = "markab";
+
+  hetzner.ipv6Address = "2a01:4f9:c010:d32a::1";
 }

--- a/servers/sadalbari/default.nix
+++ b/servers/sadalbari/default.nix
@@ -8,4 +8,6 @@
   ];
 
   networking.hostName = "sadalbari";
+
+  hetzner.ipv6Address = "2a01:4f8:1c17:6a18::1";
 }


### PR DESCRIPTION
Corresponding serokell.nix PR: https://github.com/serokell/serokell.nix/pull/19