### PR TITLE
[OPS-1150] Make helvetios and enif use different backup repositories

### DIFF
--- a/servers/helvetios/backups.nix
+++ b/servers/helvetios/backups.nix
@@ -6,7 +6,7 @@
 
   services.borgbackup.jobs.backup = {
     # https://www.notion.so/serokell/Rsync-net-797d5fdca3744aed8e17db741b7fce5a
-    repo = "12482@ch-s012.rsync.net:www";
+    repo = "12482@ch-s012.rsync.net:www-staging";
     paths = [ "/var/lib/www/files" ];
   };
 }


### PR DESCRIPTION
When they use the same repository and run backup job at the same time,
one of the servers may fail to acquire the lock on the repo