### PR TITLE
[OPS-1135] Fixes for http redirects

### DIFF
--- a/servers/enif/website.nix
+++ b/servers/enif/website.nix
@@ -35,10 +35,22 @@
     '';
 
     # redirect *.serokell.io to serokell.io
-    "*.serokell.io".globalRedirect = "serokell.io";
+    "*.serokell.io" = {
+      globalRedirect = "serokell.io";
+
+      # We enable ssl, but we don't need to issue extra certificates,
+      # because requests are sent via cloudfront to 'enif.pegasus.serokell.team',
+      # with 'Host' header forwarded
+      addSSL = true;
+      useACMEHost = "enif.pegasus.serokell.team";
+    };
 
     # redirect abf.serokell.io to serokell.io/abf
-    "abf.serokell.io".globalRedirect = "serokell.io/abf";
+    "abf.serokell.io" = {
+      globalRedirect = "serokell.io/abf";
+      addSSL = true;
+      useACMEHost = "enif.pegasus.serokell.team";
+    };
   };
 
   # Set internal hostname to be the public DNS name rather than the internal name

--- a/terraform/aws_instance_enif.tf
+++ b/terraform/aws_instance_enif.tf
@@ -55,11 +55,20 @@ resource "aws_route53_record" "enif_private_ipv4" {
   records = [aws_instance.enif.private_ip]
 }
 
-# ariadne.app alias
-resource "aws_route53_record" "ariadne_app" {
+# ariadne.app ipv4 (the record can't be CNAME because it is a zone root)
+resource "aws_route53_record" "ariadne_app_ipv4" {
   zone_id = data.aws_route53_zone.ariadne_app.zone_id
   name    = "ariadne.app"
-  type    = "CNAME"
+  type    = "A"
   ttl     = "60"
-  records = ["enif.${aws_route53_zone.pegasus_serokell_team.name}"]
+  records = [aws_eip.enif.public_ip]
+}
+
+# ariadne.app ipv6
+resource "aws_route53_record" "ariadne_app_ipv6" {
+  zone_id = data.aws_route53_zone.ariadne_app.zone_id
+  name    = "ariadne.app"
+  type    = "AAAA"
+  ttl     = "60"
+  records = [aws_instance.enif.ipv6_addresses[0]]
 }

--- a/terraform/hetzner_instance_markab.tf
+++ b/terraform/hetzner_instance_markab.tf
@@ -35,3 +35,12 @@ resource "aws_route53_record" "issues_serokell_io" {
   ttl     = "60"
   records = ["markab.${aws_route53_zone.pegasus_serokell_team.name}"]
 }
+
+# youtrack.serokell.io alias
+resource "aws_route53_record" "youtrack_serokell_io" {
+  zone_id = data.aws_route53_zone.serokell_io.zone_id
+  name    = "youtrack.serokell.io"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["markab.${aws_route53_zone.pegasus_serokell_team.name}"]
+}

--- a/terraform/hetzner_instance_sadalbari.tf
+++ b/terraform/hetzner_instance_sadalbari.tf
@@ -28,12 +28,3 @@ resource "aws_route53_record" "sadalbari_pegasus_serokell_team_ipv6" {
   ttl     = "60"
   records = [hcloud_server.sadalbari.ipv6_address]
 }
-
-# youtrack.serokell.io alias
-resource "aws_route53_record" "youtrack_serokell_io" {
-  zone_id = data.aws_route53_zone.serokell_io.zone_id
-  name    = "youtrack.serokell.io"
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["sadalbari.${aws_route53_zone.pegasus_serokell_team.name}"]
-}

--- a/terraform/serokell_io_cloudfront.tf
+++ b/terraform/serokell_io_cloudfront.tf
@@ -23,6 +23,11 @@ resource "aws_route53_record" "cert_validation" {
       record = opts.resource_record_value
       type   = opts.resource_record_type
     }
+
+    # terraform-aws provider generates duplicate records for wildcard domains,
+    # use a filter to have only one record
+    # https://github.com/hashicorp/terraform-provider-aws/issues/16913
+    if opts.domain_name == "serokell.io"
   }
 
   zone_id = data.aws_route53_zone.serokell_io.zone_id


### PR DESCRIPTION
Fixes for problems in https://github.com/serokell/pegasus-infra/pull/14

* Fix youtrack alias to point to markab instead of sadalbari
* ariadne.app cannot be a CNAME because it's the zone apex
* Work around an issue with wildcard certificates in AWS provider for terraform
* Enable SSL on enif for *.serokell.io requests

I've deployed the terraform part already