### PR TITLE
[OPS-1205] Increase restart delay for youtrack backups

### DIFF
--- a/lib/modules/backups.nix
+++ b/lib/modules/backups.nix
@@ -60,7 +60,7 @@ in {
 
       serviceConfig = {
         Restart = "on-failure";
-        RestartSec = 10;
+        RestartSec = lib.mkDefault 10;
       };
     };
 }

--- a/servers/markab/backups.nix
+++ b/servers/markab/backups.nix
@@ -45,6 +45,12 @@ in {
     '';
   };
 
+  systemd.services."borgbackup-job-backup".serviceConfig = {
+    # borgbackup job may fail if it runs while youtrack is creating a new
+    # backup, give it 5 more minutes in this case
+    RestartSec = "5min";
+  };
+
   # Oneshot systemd service to extract latest youtrack backup into /tmp/youtrack-dump.
   # Intended to be run manually
   systemd.services.extract-youtrack-backup = {


### PR DESCRIPTION
Borgbackup job on markab fails sometimes complaining about an
incomplete archive, because youtrack backup is still in progress.
Increase restart timeout after failure to 5 minutes, to give youtrack
time to finish the backup.