### PR TITLE
[PR-937] Add list of admins as env variable

### DIFF
--- a/lib/modules/website.nix
+++ b/lib/modules/website.nix
@@ -130,6 +130,8 @@ in {
     environment = {
       # PGUSER and PGDATABASE set at server level
       PGHOST = "matar";
+      ADMINS =
+        "aw@serokell.io denis.oleynikov@serokell.io dmitrii.susloparov@serokell.io gints.dreimanis@serokell.io jm@serokell.io leonid.cupikov@serokell.io olga.bolgurtseva@serokell.io seroka@serokell.io yulia.gavrilova@serokell.io";
     };
 
     serviceConfig = {


### PR DESCRIPTION
Problem: Authorized users should be separated into two groups: editors and readers. User emails are not stored in the database.

Solution: Add admins' emails via an environment variable. After user authentication in the admin panel, his/her email is saved. Then it is compared with admins list to decide whether the user is an editor or a reader